### PR TITLE
fix:  make genericlint callable from the CLI

### DIFF
--- a/release/golang.go
+++ b/release/golang.go
@@ -48,9 +48,11 @@ func (g *Golang) Check(ctx context.Context,
 
 	p.Go(func(ctx context.Context) error {
 		// shellcheck, yamllint, markdownlint
-		if err := g.Release.genericLint(ctx, results, base); err != nil {
+		_, err := g.Release.GenericLint(ctx, base)
+		if err != nil {
 			return fmt.Errorf("running generic linters: %w", err)
 		}
+		results.Add("Generic Linters", "success")
 		return nil
 	})
 

--- a/release/lint.go
+++ b/release/lint.go
@@ -13,10 +13,12 @@ import (
 // This file contains generic linters used in 'Check' commands for various project types. Language specific linters are used in their respective groups.
 
 // genericLint runs generic linters, e.g. markdown, yaml, etc.
-func (r *Release) genericLint(ctx context.Context,
-	results util.ResultsFormatter,
+func (r *Release) GenericLint(ctx context.Context,
+	// +optional
 	base *dagger.Container,
-) error {
+) (string, error) {
+	results := util.NewResultsBasicFmt(strings.Repeat("=", 15))
+
 	p := pool.New().
 		WithErrors().
 		WithContext(ctx)
@@ -50,7 +52,11 @@ func (r *Release) genericLint(ctx context.Context,
 		return nil
 	})
 
-	return p.Wait()
+	if err := p.Wait(); err != nil {
+		return "", err
+	}
+
+	return results.String(), nil
 }
 
 // shellcheck auto-detects and runs on all *.sh and *.bash files in the source directory.

--- a/release/python.go
+++ b/release/python.go
@@ -46,9 +46,11 @@ func (p *Py) Check(ctx context.Context,
 
 	pl.Go(func(ctx context.Context) error {
 		// shellcheck, yamllint, markdownlint
-		if err := p.Release.genericLint(ctx, results, Base); err != nil {
+		_, err := p.Release.GenericLint(ctx, Base)
+		if err != nil {
 			return fmt.Errorf("running generic linters: %w", err)
 		}
+		results.Add("Generic Linters", "success")
 		return nil
 	})
 


### PR DESCRIPTION
closes #33 